### PR TITLE
correccion de dtos de imagen y alojamiento

### DIFF
--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/Controller/ImagenController.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/Controller/ImagenController.java
@@ -1,5 +1,6 @@
 package com.NomadNook.NomadNook.Controller;
 
+import com.NomadNook.NomadNook.DTO.RESPONSE.ImagenResponse;
 import com.NomadNook.NomadNook.Model.Imagen;
 import com.NomadNook.NomadNook.Service.IImagenService;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class ImagenController {
     }
 
     @GetMapping("/listarTodos")
-    public ResponseEntity<List<Imagen>> getAll() {
+    public ResponseEntity<List<ImagenResponse>> getAll() {
         return ResponseEntity.ok(imagenService.listAllImagen());
     }
 
@@ -29,7 +30,7 @@ public class ImagenController {
     }
 
     @PostMapping("/guardar")
-    public ResponseEntity<Imagen> create(@RequestBody Imagen imagen) {
+    public ResponseEntity<ImagenResponse> create(@RequestBody Imagen imagen) {
         return ResponseEntity.ok(imagenService.createImagen(imagen));
     }
 

--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/DTO/RESPONSE/ImagenResponse.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/DTO/RESPONSE/ImagenResponse.java
@@ -7,16 +7,13 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
-@Getter
-@Setter
-@Builder
 @Data
-
+@NoArgsConstructor
 public class ImagenResponse {
 
     private Long id;
 
     private String url;
 
-    private Alojamiento alojamiento;
+    private Long alojamiento_id;
 }

--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/Security/AuthController.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/Security/AuthController.java
@@ -94,7 +94,7 @@ public class AuthController {
                     .token(token)
                     .email(usuario.getEmail())
                     .rol(usuario.getRol())
-                    .mensaje("Login exitoso")
+                    .mensaje("Registro exitoso")
                     .build();
 
             return ResponseEntity.ok(response);

--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/IImagenService.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/IImagenService.java
@@ -1,13 +1,14 @@
 package com.NomadNook.NomadNook.Service;
 
+import com.NomadNook.NomadNook.DTO.RESPONSE.ImagenResponse;
 import com.NomadNook.NomadNook.Model.Imagen;
 
 import java.util.List;
 
 public interface IImagenService {
-    Imagen createImagen(Imagen usuario);
+    ImagenResponse createImagen(Imagen usuario);
     Imagen getImagenById(Long id);
-    List<Imagen> listAllImagen();
+    List<ImagenResponse> listAllImagen();
     Imagen updateImagen(Long id, Imagen usuario);
     void deleteImagen(Long id);
 }

--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/Impl/AlojamientoService.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/Impl/AlojamientoService.java
@@ -48,7 +48,9 @@ public class AlojamientoService implements IAlojamientoService {
         Alojamiento alojamientoGuardado = alojamientoRepository.save(alojamiento);
 
         // Mapear la entidad persistida a un DTO de respuesta
-        return modelMapper.map(alojamientoGuardado, AlojamientoResponse.class);
+        AlojamientoResponse response = modelMapper.map(alojamientoGuardado, AlojamientoResponse.class);
+        response.setPropietario_id(requestDTO.getPropietario().getId());
+        return response;
     }
 
 

--- a/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/Impl/ImagenService.java
+++ b/NomadNook/src/main/java/com/NomadNook/NomadNook/Service/Impl/ImagenService.java
@@ -1,16 +1,20 @@
 package com.NomadNook.NomadNook.Service.Impl;
 
+import com.NomadNook.NomadNook.DTO.RESPONSE.AlojamientoResponse;
+import com.NomadNook.NomadNook.DTO.RESPONSE.ImagenResponse;
 import com.NomadNook.NomadNook.Exception.ResourceNotFoundException;
 import com.NomadNook.NomadNook.Model.Imagen;
 import com.NomadNook.NomadNook.Repository.IImagenRepository;
 import com.NomadNook.NomadNook.Service.IImagenService;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,16 +23,18 @@ public class ImagenService implements IImagenService {
     private final IImagenRepository imagenRepository;
     private final Logger LOGGER = LoggerFactory.getLogger(ImagenService.class);  // Corregido
     private final Validator validator;
+    private ModelMapper modelMapper;
 
     // Inyección del Validator mediante el constructor
     @Autowired
-    public ImagenService(IImagenRepository imagenRepository, Validator validator) {
+    public ImagenService(IImagenRepository imagenRepository, Validator validator, ModelMapper modelMapper) {
         this.imagenRepository = imagenRepository;
         this.validator = validator;
+        this.modelMapper = modelMapper;
     }
 
     @Override
-    public Imagen createImagen(Imagen imagen) {
+    public ImagenResponse createImagen(Imagen imagen) {
         // Validar antes de guardar la imagen
         var violations = validator.validate(imagen);
         if (!violations.isEmpty()) {
@@ -36,8 +42,10 @@ public class ImagenService implements IImagenService {
         }
 
         Imagen savedImagen = imagenRepository.save(imagen);
+        ImagenResponse response = modelMapper.map(savedImagen, ImagenResponse.class);
+        response.setAlojamiento_id(imagen.getAlojamiento().getId());
         LOGGER.info("Imagen creada con id: {}", savedImagen.getId());
-        return savedImagen;
+        return response;
     }
 
     @Override
@@ -47,8 +55,17 @@ public class ImagenService implements IImagenService {
     }
 
     @Override
-    public List<Imagen> listAllImagen() {
-        return imagenRepository.findAll();
+    public List<ImagenResponse> listAllImagen() {
+
+        List<Imagen> imagenes = imagenRepository.findAll();
+        List<ImagenResponse> responses = new ArrayList<>();
+        for(Imagen imagen: imagenes) {
+            Imagen savedImagen = imagenRepository.save(imagen);
+            ImagenResponse response = modelMapper.map(savedImagen, ImagenResponse.class);
+            response.setAlojamiento_id(imagen.getAlojamiento().getId());
+            responses.add(response);
+        }
+        return responses;
     }
 
     @Override


### PR DESCRIPTION
ChangeLog

Arreglando en AlojamientoService
- retorno de createAlojamiento para que muestre el propietario_id en vez del objeto propietario

Agregando ImagenResponse a ImagenService
- retorno de createImagen para que muestre el alojamiento_id en vez del objeto alojamiento
- retorno de listAllImagen() para que muestre el alojamiento_id en vez del objeto alojamiento